### PR TITLE
delete useless code to avoid fp8e4m3 benchmark error

### DIFF
--- a/compute/accelerator/benchmarks/mamf-finder.py
+++ b/compute/accelerator/benchmarks/mamf-finder.py
@@ -234,7 +234,6 @@ def benchmark_mm(m, n, k, dtype, device, num_iterations, num_warmup_iterations):
 
         # some torch versions require the scale arg, some don't so discover which is required
         try:
-            C = torch._scaled_mm(A, B)
             @time_it(total_iterations)
             def time_iterations():
                 C = torch._scaled_mm(A, B)


### PR DESCRIPTION
To solve the bug:

```shell
Traceback (most recent call last):
  File "/home/xingzai/mamf-finder.py", line 353, in <module>
    _ = benchmark_mm(m[0], n[0], k[0], dtype, device, args.num_iterations, args.num_warmup_iterations)
  File "/home/xingzai/mamf-finder.py", line 255, in benchmark_mm
    times = time_iterations()[num_warmup_iterations:]
  File "/home/xingzai/mamf-finder.py", line 216, in func_wrapper
    C.copy_(C_rand)  # re-randomize the target matrix
AttributeError: 'tuple' object has no attribute 'copy_'
```